### PR TITLE
Update code to run on Elixir 1.0+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/_build
 /ebin
 /cover
 erl_crash.dump

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ clean:
 	@ echo "==> Adding Erlang/OTP basic applications to PLT"
 	@ dialyzer --output_plt .dialyzer_plt --build_plt --apps erts kernel stdlib compiler syntax_tools inets crypto ssl
 	@ echo "==> Adding Elixir to PLT..."
-	@ dialyzer --plt .dialyzer_plt --add_to_plt -r $(ELIXIR_PATH)/lib/*/ebin
+	@ dialyzer --plt .dialyzer_plt --add_to_plt -r _build/dev/lib/graphviz/ebin/
 
 dialyze: .dialyzer_plt compile
 	@ echo "==> Dialyzing GraphViz..."
-	@ dialyzer --plt .dialyzer_plt -r ebin
+	@ dialyzer --plt .dialyzer_plt -r _build/dev/lib/graphviz/ebin/

--- a/README.md
+++ b/README.md
@@ -54,15 +54,15 @@ Otherwise this is a fairly complete way to generate GraphViz diagrams.
 
 First, create a new graph:
 
-    graph = GraphViz.Graph[ name: "name", is_strict: true, is_directed: true, attributes: [ label: "A label", rankdir: :LR ] ]
+    graph = %GraphViz.Graph{ name: "name", is_strict: true, is_directed: true, attributes: [ label: "A label", rankdir: :LR ] }
 
 Then, add stuff into the graph:
 
     graph = graph
-         |> GraphViz.add(GraphViz.SubGraph[ id: id_of_cluster, is_cluster: true, attributes: [ label: "Cluster" ] ])
-         |> GraphViz.add(GraphViz.Node[ id: id_of_source, parent: id_of_cluster, attributes: [ label: "Source" ] ])
-         |> GraphViz.add(GraphViz.Node[ id: id_of_target, attributes: [ label: "Target" ] ])
-         |> GraphViz.add(GraphViz.Edge[ id: id_of_edge, source: id_of_source, target: id_of_target, attributes: [ label: "Edge" ] ])
+         |> GraphViz.add(%GraphViz.SubGraph{ id: id_of_cluster, is_cluster: true, attributes: [ label: "Cluster" ] })
+         |> GraphViz.add(%GraphViz.Node{ id: id_of_source, parent: id_of_cluster, attributes: [ label: "Source" ] })
+         |> GraphViz.add(%GraphViz.Node{ id: id_of_target, attributes: [ label: "Target" ] })
+         |> GraphViz.add(%GraphViz.Edge{ id: id_of_edge, source: id_of_source, target: id_of_target, attributes: [ label: "Edge" ] })
 
 You will need to use some sort of a unique identifier for each element
 (including edges!). Using references (`make_ref`) is OK, as is using anything

--- a/lib/graphviz.ex
+++ b/lib/graphviz.ex
@@ -55,15 +55,15 @@ defmodule GraphViz do
 
   First, create a new graph:
 
-      graph = GraphViz.Graph[ name: "name", is_strict: true, is_directed: true, attributes: [ label: "A label", rankdir: :LR ] ]
+      graph = %GraphViz.Graph{ name: "name", is_strict: true, is_directed: true, attributes: [ label: "A label", rankdir: :LR ] }
 
   Then, add stuff into the graph:
 
       graph = graph
-           |> GraphViz.add(GraphViz.SubGraph[ id: id_of_cluster, is_cluster: true, attributes: [ label: "Cluster" ] ])
-           |> GraphViz.add(GraphViz.Node[ id: id_of_source, parent: id_of_cluster, attributes: [ label: "Source" ] ])
-           |> GraphViz.add(GraphViz.Node[ id: id_of_target, attributes: [ label: "Target" ] ])
-           |> GraphViz.add(GraphViz.Edge[ id: id_of_edge, source: id_of_source, target: id_of_target, attributes: [ label: "Edge" ] ])
+           |> GraphViz.add(%GraphViz.SubGraph{ id: id_of_cluster, is_cluster: true, attributes: [ label: "Cluster" ] })
+           |> GraphViz.add(%GraphViz.Node{ id: id_of_source, parent: id_of_cluster, attributes: [ label: "Source" ] })
+           |> GraphViz.add(%GraphViz.Node{ id: id_of_target, attributes: [ label: "Target" ] })
+           |> GraphViz.add(%GraphViz.Edge{ id: id_of_edge, source: id_of_source, target: id_of_target, attributes: [ label: "Edge" ] })
 
   You will need to use some sort of a unique identifier for each element
   (including edges!). Using references (`make_ref`) is OK, as is using anything
@@ -92,116 +92,108 @@ defmodule GraphViz do
   # long as identifiers are unique.
   @type id :: any
 
-  defrecord Graph, name: nil, is_directed: nil, is_strict: nil, elements: [], by_id: HashDict.new, attributes: [], data: nil do
+  defmodule Graph do
     @moduledoc """
     A graph contains the top-level elements (nodes or sub-graphs) and edges
     connecting the nodes.
     """
-
-    # The name of the graph.
-    record_type name: String.t
-
-    # Whether this is a directed graph.
-    record_type is_directed: boolean
-
-    # Whether this is a strict graph (only one edge between two nodes).
-    record_type is_strict: boolean
-
-    # A list of all the root elements.
-    record_type elements: [ GraphViz.id ]
-
-    # Map unique identifiers to the matching object. This covers all the
-    # elements regardless of where they are.
-    record_type by_id: Dict.t
-
-    # Optional additional graph attributes.
-    record_type attributes: [ Keyword.t ]
-
-    # Optional additional arbitrary data. This doesn't impact the generated
-    # diagram in any way.
-    record_type data: any
+    defstruct name: nil, is_directed: nil, is_strict: nil, elements: [], by_id: %{}, attributes: [], data: nil
   end
 
-  defrecord SubGraph, id: nil, parent: nil, is_cluster: nil, attributes: [], elements: [], data: nil do
+  @type tgraph :: %Graph {
+      # The name of the graph.
+      name: String.t,
+      # Whether this is a directed graph.
+      is_directed: boolean,
+      # Whether this is a strict graph (only one edge between two nodes).
+      is_strict: boolean,
+      # A list of all the root elements.
+      elements: [GraphViz.id],
+      # Map unique identifiers to the matching object. This covers all the
+      # elements regardless of where they are.
+      by_id: Dict.t,
+      # Optional additional graph attributes.
+      attributes: [Keyword.t],
+      # Optional additional arbitrary data. This doesn't impact the generated
+      # diagram in any way.
+      data: any
+  }
+
+
+  defmodule SubGraph do
     @moduledoc """
     A sub-graph groups together multiple elements. This scopes attributes etc.
     If it is also a cluster, then `dot` will lay it in a box.
     """
-
-    # The sub-graph's unique identifier.
-    record_type id: GraphViz.id
-
-    # The sub-graph's parent identifier. A `nil` indicates this is
-    # directly under the graph.
-    record_type parent: GraphViz.id | nil
-
-    # Whether this should be considered a cluster for `dot`. If it is, its
-    # name in the generated dot file will be prefixed with `cluster_`.
-    record_type is_cluster: boolean
-
-    # Optional additional cluster attributes.
-    record_type attributes: [ Keyword.t ]
-
-    # The elements contained in the cluster.
-    record_type elements: [ GraphViz.id ]
-
-    # Optional additional arbitrary data. This doesn't impact the generated
-    # diagram in any way.
-    record_type data: any
+    defstruct id: nil, parent: nil, is_cluster: nil, attributes: [], elements: [], data: nil
   end
 
-  defrecord Node, id: nil, parent: nil, attributes: [], outgoing: [], incoming: [], data: nil do
+  @type tsubgraph :: %SubGraph {
+    # The sub-graph's unique identifier.
+    id: GraphViz.id,
+    # The sub-graph's parent identifier. A `nil` indicates this is
+    # directly under the graph.
+    parent: GraphViz.id | nil,
+    # Whether this should be considered a cluster for `dot`. If it is, its
+    # name in the generated dot file will be prefixed with `cluster_`.
+    is_cluster: boolean,
+    # Optional additional cluster attributes.
+    attributes: [ Keyword.t ],
+    # The elements contained in the cluster.
+    elements: [ GraphViz.id ],
+    # Optional additional arbitrary data. This doesn't impact the generated
+    # diagram in any way.
+    data: any
+  }
+
+  defmodule Node do
     @moduledoc """
     A node represents an atomic shape in the diagram. Actually, GraphViz
     recognizes sub-structure inside nodes (especially if they are record or
     HTML table nodes). But the node parts are all addressed using attributes so
     we ignore this.
     """
-
-    # The node's unique identifier.
-    record_type id: GraphViz.id
-
-    # The node's parent identifier. A `nil` indicates this is directly under
-    # the graph.
-    # the complete graph.
-    record_type parent: GraphViz.id | nil
-
-    # Optional additional node attributes.
-    record_type attributes: [ Keyword.t ]
-
-    # List of edges originating at this node.
-    record_type outgoing: [ GraphViz.id ]
-
-    # List of edges terminating at this node.
-    record_type incoming: [ GraphViz.id ]
-
-    # Optional additional arbitrary data. This doesn't impact the generated
-    # diagram in any way.
-    record_type data: any
+    defstruct id: nil, parent: nil, attributes: [], outgoing: [], incoming: [], data: nil
   end
 
-  defrecord Edge, id: nil, source: nil, target: nil, attributes: [], data: nil do
+  @type tnode :: %Node {
+    # The node's unique identifier.
+    id: GraphViz.id,
+    # The node's parent identifier. A `nil` indicates this is directly under
+    # the graph. the complete graph.
+    parent: GraphViz.id | nil,
+    # Optional additional node attributes.
+    attributes: [ Keyword.t ],
+    # List of edges originating at this node.
+    outgoing: [ GraphViz.id ],
+    # List of edges terminating at this node.
+    incoming: [ GraphViz.id ],
+    # Optional additional arbitrary data. This doesn't impact the generated
+    # diagram in any way.
+    data: any
+  }
+
+  defmodule Edge do
     @moduledoc """
     An edge connects two nodes. In directed graphs, this causes `dot` to impose
     a rank constraint between the source and target nodes.
     """
+    defstruct id: nil, source: nil, target: nil, attributes: [], data: nil
+  end
 
+  @type t :: %Edge {
     # The edge's unique identifier.
-    record_type id: GraphViz.id
-
+    id: GraphViz.id,
     # The edge's source node.
-    record_type source: GraphViz.id
-
+    source: GraphViz.id,
     # The edge's target node.
-    record_type target: GraphViz.id
-
+    target: GraphViz.id,
     # Optional additional edge attributes.
-    record_type attributes: [ Keyword.t ]
-
+    attributes: [ Keyword.t ],
     # Optional additional arbitrary data. This doesn't impact the generated
     # diagram in any way.
-    record_type data: any
-  end
+    data: any
+  }
 
   # The types of elements a graph may contain.
   @type element :: SubGraph.t | Node.t | Edge.t
@@ -211,7 +203,7 @@ defmodule GraphViz do
   """
   @spec lookup(Graph.t, id) :: element
 
-  def lookup(graph = Graph[], id) do
+  def lookup(%Graph{} = graph, id) do
     Dict.get(graph.by_id, id)
   end
 
@@ -234,40 +226,40 @@ defmodule GraphViz do
   """
   @spec update(Graph.t, element) :: Graph.t
 
-  def update(graph = Graph[], sub_graph = SubGraph[]) do
-    graph.update_by_id(fn(dictionary) -> Dict.put(dictionary, sub_graph.id, sub_graph) end)
+  def update(%Graph{} = graph, %SubGraph{} = sub_graph) do
+    %{graph | by_id: Dict.put(graph.by_id, sub_graph.id, sub_graph)}
   end
 
-  def update(graph = Graph[], node = Node[]) do
-    graph.update_by_id(fn(dictionary) -> Dict.put(dictionary, node.id, node) end)
+  def update(  %Graph{} = graph, %Node{} = node) do
+    %{graph | by_id: Dict.put(graph.by_id, node.id, node)}
   end
 
-  def update(graph = Graph[], edge = Edge[]) do
-    graph.update_by_id(fn(dictionary) -> Dict.put(dictionary, edge.id, edge) end)
+  def update(%Graph{} = graph, %Edge{} = edge) do
+    %{graph | by_id: Dict.put(graph.by_id, edge.id, edge)}
   end
 
   # Connect an element to all the other related elements in the graph.
   @spec connect(Graph.t, element) :: Graph.t
 
-  defp connect(graph = Graph[], sub_graph = SubGraph[]) do
+  defp connect(%Graph{} = graph, %SubGraph{} = sub_graph) do
     case sub_graph.parent do
       nil ->
-        graph.update_elements([ sub_graph.id | &1 ])
+        %{ graph | elements: [sub_graph.id | graph.elements]}
       parent ->
         graph |> update(add_sub_element(lookup(graph, parent), sub_graph.id))
     end
   end
 
-  defp connect(graph = Graph[], node = Node[]) do
+  defp connect(%Graph{} = graph, %Node{} = node) do
     case node.parent do
       nil ->
-        graph.update_elements([ node.id | &1 ])
+        %{ graph | elements: [node.id | graph.elements]}
       parent ->
         graph |> update(add_sub_element(lookup(graph, parent), node.id))
     end
   end
 
-  defp connect(graph = Graph[], edge = Edge[]) do
+  defp connect(%Graph{} = graph, %Edge{} = edge) do
     graph |> update(add_outgoing_edge(lookup(graph, edge.source), edge.id))
           |> update(add_incoming_edge(lookup(graph, edge.target), edge.id))
   end
@@ -275,22 +267,23 @@ defmodule GraphViz do
   # Add a sub-element to a parent element.
   @spec add_sub_element(SubGraph.t, id) :: Graph.t | SubGraph.t
 
-  defp add_sub_element(sub_graph = SubGraph[], id) do
-    sub_graph.update_elements([ id | &1 ])
+  defp add_sub_element(%SubGraph{} = sub_graph, id) do
+    %{sub_graph | elements: [id | sub_graph.elements]}
   end
 
   # Add an incoming edge to a node.
   @spec add_incoming_edge(Node.t, id) :: Node.t
 
-  def add_incoming_edge(node = Node[], id) do
-    node.update_incoming([ id | &1 ])
+  def add_incoming_edge(%Node{} = node, id) do
+    %{node | incoming: [id | node.incoming ]}
   end
 
   # Add an outgoing edge to a node.
   @spec add_outgoing_edge(Node.t, id) :: Node.t
 
-  def add_outgoing_edge(node = Node[], id) do
-    node.update_outgoing([ id | &1 ])
+  def add_outgoing_edge(%Node{} = node, id) do
+    %{node | outgoing: [id | node.outgoing]}
+    #node.update_outgoing([ id | &1 ])
   end
 
   @doc """
@@ -298,7 +291,7 @@ defmodule GraphViz do
   """
   @spec print(:io.device, Graph.t) :: :ok
 
-  def print(device, graph = Graph[]) do
+  def print(device, %Graph{} = graph) do
     if graph.is_strict do
       IO.write(device, "strict ")
     end
@@ -309,14 +302,15 @@ defmodule GraphViz do
     end
     IO.write(device, inspect(graph.name))
     IO.puts(device, " {")
-    graph.elements |> Enum.each print_id(device, graph, &1)
+    graph.elements |> Enum.each fn x -> print_id(device, graph, x) end
     edge_separator = if graph.is_directed do
                        "->"
                      else
                        "--"
                      end
-    graph.by_id |> Dict.to_list |> Enum.each print_edge(device, edge_separator, &1)
-    graph.attributes |> Enum.each print_attribute(device, &1, ";")
+    graph.by_id |> Dict.to_list |> Enum.each fn x -> print_edge(device, edge_separator, x) end
+
+    graph.attributes |> Enum.each fn x -> print_attribute(device, x, ";") end
     IO.puts(device, "}")
     :ok
   end
@@ -324,28 +318,28 @@ defmodule GraphViz do
   # Print a nested graph element by its id.
   @spec print_id(:io.device, Graph.t, id) :: :ok
 
-  defp print_id(device, graph = Graph[], id) do
+  defp print_id(device, %Graph{} = graph, id) do
     print_element(device, graph, lookup(graph, id))
   end
 
   # Print a nested graph element.
-  @spec print_element(:io.device, graph :: Graph[], Graph.t | Node.t) :: :ok
+  @spec print_element(:io.device, graph :: %Graph{}, Graph.t | Node.t) :: :ok
 
-  defp print_element(device, graph = Graph[], sub_graph = SubGraph[]) do
+  defp print_element(device, %Graph{} = graph, %SubGraph{} = sub_graph) do
     if sub_graph.is_cluster do
       IO.puts(device, "subgraph \"cluster_#{inspect(sub_graph.id)}\" {")
     else
       IO.puts(device, "subgraph \"#{inspect(sub_graph.id)}\" {")
     end
-    sub_graph.elements |> Enum.each print_id(device, graph, &1)
-    sub_graph.attributes |> Enum.each print_attribute(device, &1, ";")
+    sub_graph.elements |> Enum.each fn x -> print_id(device, graph, x) end
+    sub_graph.attributes |> Enum.each fn x -> print_attribute(device, x, ";") end
     IO.puts(device, "}")
     :ok
   end
 
-  defp print_element(device, _graph, node = Node[]) do
+  defp print_element(device, _graph, %Node{} = node) do
     IO.puts(device, "\"#{inspect(node.id)}\" [")
-    node.attributes |> Enum.each print_attribute(device, &1, ",")
+    node.attributes |> Enum.each fn x-> print_attribute(device, x, ",") end
     IO.puts(device, "];") # HACK: This allows us to print each of the real attributes with a final ",".
     :ok
   end
@@ -355,9 +349,9 @@ defmodule GraphViz do
   # belong to any of the sub-graphs.
   @spec print_edge(:io.device, separator :: String.t, { id, element }) :: :ok
 
-  defp print_edge(device, separator, { _id, edge = Edge[] }) do
+  defp print_edge(device, separator, { _id, %Edge{} = edge }) do
     IO.puts(device, "\"#{inspect(edge.source)}\" #{separator} \"#{inspect(edge.target)}\" [")
-    edge.attributes |> Enum.each print_attribute(device, &1, ",")
+    edge.attributes |> Enum.each fn x -> print_attribute(device, x, ",") end
     IO.puts(device, "];")
     :ok
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,8 +1,12 @@
-defmodule ExUnit.Mixfile do
+defmodule GraphViz.Mixfile do
   use Mix.Project
 
   def project do
-    [ app: :graphviz, version: "0.1" ]
+    [
+      app: :graphviz,
+      version: "0.2.0",
+      elixir: "~> 1.0",
+    ]
   end
 
 end

--- a/test/print_test.exs
+++ b/test/print_test.exs
@@ -1,33 +1,34 @@
-Code.require_file "../test_helper.exs", __FILE__
+#Code.require_file "../test_helper.exs", __FILE__
 
 defmodule PrintTest do
 
   use GvTest.Case, async: true
 
+
   test "print empty graphs" do
-    assert_prints GraphViz.print(&1, GraphViz.Graph[ name: "name", is_strict: false, is_directed: false ]), """
+    assert_prints &(GraphViz.print(&1, %GraphViz.Graph{ name: "name", is_strict: false, is_directed: false })), """
     graph "name" {
     }
     """
-    assert_prints GraphViz.print(&1, GraphViz.Graph[ name: "name", is_strict: true, is_directed: false ]), """
+    assert_prints &(GraphViz.print(&1, %GraphViz.Graph{ name: "name", is_strict: true, is_directed: false })), """
     strict graph "name" {
     }
     """
-    assert_prints GraphViz.print(&1, GraphViz.Graph[ name: "name", is_strict: false, is_directed: true ]), """
+    assert_prints &(GraphViz.print(&1, %GraphViz.Graph{ name: "name", is_strict: false, is_directed: true })), """
     digraph "name" {
     }
     """
   end
 
   test "print directed graph" do
-    graph = GraphViz.Graph[ name: "name", is_strict: true, is_directed: true,
-                            attributes: [ label: inspect("A label"), rankdir: :LR ] ]
-         |> GraphViz.add(GraphViz.SubGraph[ id: :cluster, is_cluster: true, attributes: [ label: "Cluster" ] ])
-         |> GraphViz.add(GraphViz.SubGraph[ id: :sub_graph, parent: :cluster, is_cluster: false ])
-         |> GraphViz.add(GraphViz.Node[ id: :source, parent: :sub_graph, attributes: [ label: "Source" ] ])
-         |> GraphViz.add(GraphViz.Node[ id: :target, attributes: [ label: "Target" ] ])
-         |> GraphViz.add(GraphViz.Edge[ id: :edge, source: :source, target: :target, attributes: [ label: "Edge" ] ])
-    assert_prints GraphViz.print(&1, graph), """
+    graph = %GraphViz.Graph{ name: "name", is_strict: true, is_directed: true,
+                             attributes: [ label: inspect("A label"), rankdir: :LR ]}
+         |> GraphViz.add(%GraphViz.SubGraph{ id: :cluster, is_cluster: true, attributes: [ label: "Cluster" ]})
+         |> GraphViz.add(%GraphViz.SubGraph{ id: :sub_graph, parent: :cluster, is_cluster: false})
+         |> GraphViz.add(%GraphViz.Node{ id: :source, parent: :sub_graph, attributes: [ label: "Source" ]})
+         |> GraphViz.add(%GraphViz.Node{ id: :target, attributes: [ label: "Target" ]})
+         |> GraphViz.add(%GraphViz.Edge{ id: :edge, source: :source, target: :target, attributes: [ label: "Edge" ]})
+    assert_prints &(GraphViz.print(&1, graph)), """
     strict digraph "name" {
     ":target" [
     label = Target,

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,25 +1,3 @@
-# This assumes that the patched version of `cover.erl` was installed. If you
-# don't, this will fail horribly! Arguably, the ExUnit library should provide
-# direct support for this, including some better reporting of the aggregated
-# coverage results.
-if System.argv |> Enum.member?("--coverage") do
-  IO.puts "Preparing for collecting coverage..."
-  :cover.start
-  beam = Path.expand("../../ebin", __FILE__) |> to_char_list
-  :cover.compile_beam_directory(beam)
-
-  System.at_exit fn(_) ->
-    IO.puts "Generating cover results..."
-
-    cover_dir = Path.expand("../../cover", __FILE__)
-    File.mkdir_p!(cover_dir)
-
-    Enum.each :cover.modules, fn(mod) ->
-      :cover.analyse_to_file(mod, '#{cover_dir}/#{mod}.html', [:html]) |> IO.inspect
-    end
-  end
-end
-
 ExUnit.start []
 
 # This is a subset of what the mix test helper does. Arguably, the ExUnit
@@ -33,13 +11,14 @@ defmodule GvTest.Case do
     end
   end
 
-  teardown do
-    del_tmp_paths
-    :ok
+  setup do
+    on_exit fn ->
+      del_tmp_paths
+    end
   end
 
   def fixture_path do
-    Path.expand("../fixtures", __FILE__)
+    Path.expand("../fixtures", "./test/test_helper.exs")
   end
 
   def fixture_path(extension) do
@@ -47,7 +26,7 @@ defmodule GvTest.Case do
   end
 
   def tmp_path do
-    Path.expand("../../tmp", __FILE__)
+    Path.expand("../../tmp", "./test/test_helper.exs")
   end
 
   def tmp_path(extension) do
@@ -55,9 +34,9 @@ defmodule GvTest.Case do
   end
 
   def del_tmp_paths do
-    tmp = tmp_path |> binary_to_list
-    to_remove = Enum.filter :code.get_path, fn(path) -> :string.str(path, tmp) != 0 end
-    Enum.map to_remove, :code.del_path(&1)
+    #tmp = tmp_path |> binary_to_list
+    #to_remove = Enum.filter :code.get_path, fn(path) -> :string.str(path, tmp) != 0 end
+    #Enum.map to_remove, fn x -> :code.del_path(x) end
   end
 
   def in_tmp(which, function) do


### PR DESCRIPTION
This is quite a large PR (sorry) which modifies the code to allow it to run on Elixir >= 1.0 and to close #1 

It:
- Replaces use of records with structs, and access to structs by using
  normal struct %{g | field:val}. Typing moved from record_type to type x :: *
- Replaces update__field_ with struct access/update.
- Removes cover arg from tests as this is now provided by ExUnit
- Tests are passing
